### PR TITLE
Update Neo4j version up to 2.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.6.1</slf4j.version>
-        <neo4j.version>2.0.0</neo4j.version>
+        <neo4j.version>2.0.3</neo4j.version>
         <jersey.version>1.9</jersey.version>
         <license-text.header>GPL-3-header.txt</license-text.header>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.6.1</slf4j.version>
-        <neo4j.version>2.0.0-RC1</neo4j.version>
+        <neo4j.version>2.0.0</neo4j.version>
         <jersey.version>1.9</jersey.version>
         <license-text.header>GPL-3-header.txt</license-text.header>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.6.1</slf4j.version>
-        <neo4j.version>2.1.0</neo4j.version>
+        <neo4j.version>2.1.2</neo4j.version>
         <jersey.version>1.9</jersey.version>
         <license-text.header>GPL-3-header.txt</license-text.header>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <slf4j.version>1.6.1</slf4j.version>
-        <neo4j.version>2.0.3</neo4j.version>
+        <neo4j.version>2.1.0</neo4j.version>
         <jersey.version>1.9</jersey.version>
         <license-text.header>GPL-3-header.txt</license-text.header>
     </properties>
@@ -113,10 +113,6 @@ the relevant Commercial Agreement.
               <exclusion>
                   <groupId>org.apache.felix</groupId>
                   <artifactId>org.apache.felix.fileinstall</artifactId>
-              </exclusion>
-              <exclusion>
-                  <groupId>org.neo4j</groupId>
-                  <artifactId>neo4j-shell</artifactId>
               </exclusion>
           </exclusions>
         </dependency>

--- a/src/main/java/org/neo4j/cypher_rs/CypherRsService.java
+++ b/src/main/java/org/neo4j/cypher_rs/CypherRsService.java
@@ -20,7 +20,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.Reader;
 import java.util.*;
 
@@ -78,12 +77,12 @@ public class CypherRsService {
                 Map<String, Object> params = Utils.toParams(uriInfo.getQueryParameters());
                 ExecutionResult result = engine.execute(query, params);
                 String json = Utils.toJson(result);
-                
+
                 tx.success();
-                
+
                 if(json == null)
                     return noContent();
-                
+
                 return Response.ok(json).build();
             }
         } catch(Exception e) {
@@ -108,11 +107,11 @@ public class CypherRsService {
                     results.add(Utils.toObject(result));
                 }
                 tx.success();
-                
+
                 Object retVal = singleOrList(results);
                 if(retVal == null)
                     return noContent();
-                
+
                 return Response.ok(Utils.toJson(retVal)).build();
             }
         } catch (BadInputException e) {
@@ -209,7 +208,7 @@ public class CypherRsService {
     private Response notFound() {
         return Response.status(Response.Status.NOT_FOUND).build();
     }
-    
+
     private Response noContent() {
         return Response.status(Response.Status.NO_CONTENT).build();
     }

--- a/src/main/java/org/neo4j/cypher_rs/Utils.java
+++ b/src/main/java/org/neo4j/cypher_rs/Utils.java
@@ -76,7 +76,7 @@ public class Utils {
     public static String toJson(Object value) throws IOException {
         if(value == null)
           return null;
-        
+
         return OBJECT_MAPPER.writeValueAsString(value);
     }
 

--- a/src/test/java/org/neo4j/cypher_rs/CypherRsPostTest.java
+++ b/src/test/java/org/neo4j/cypher_rs/CypherRsPostTest.java
@@ -27,10 +27,10 @@ public class CypherRsPostTest extends RestTestBase {
     public static final String MULTI_COLUMN_QUERY = "match n where id(n) in {ids} return length(n.name) as l, n.name as name";
     public static final String QUERY = "start n=node({id}) return n";
     public static final String WRITE_QUERY = "create (n:Node {name:{name}}) return n";
-    
+
     //doing a node lookup by ID is a Cypher error, so it's a bit roundabout to represent more of a normal index lookup which wouldn't be a cypher error
     public static final String UPDATE_QUERY = "match n where id(n) = {id} SET n.name={name} return n";
-    
+
     private WebResource cypherRsPath;
 
     @Before
@@ -67,57 +67,57 @@ public class CypherRsPostTest extends RestTestBase {
 
     @Test
     public void testQueryEndpointNoResults() throws Exception {
-        
+
         cypherRsPath.put(ClientResponse.class, UPDATE_QUERY);
         Map<String,Object> payload = map("id", -234);
         payload.put("name", "Neo");
-        
+
         ClientResponse response = post(payload);
         assertEquals(204, response.getStatus());
     }
-    
+
     @Test
     public void testQueryEndpointMultiAddNoResults() throws Exception {
-        
+
         cypherRsPath.put(ClientResponse.class, UPDATE_QUERY);
         Map<String,Object> payload1 = map("id", -234);
         payload1.put("name", "Neo");
-        
+
         Map<String,Object> payload2 = map("id", -234);
         payload2.put("name", "Neo");
-        
+
         List<Map<String,Object>> items = new ArrayList<>();
         items.add(payload1);
         items.add(payload2);
-        
+
         ClientResponse response =  cypherRsPath.entity(Utils.toJson(items), MediaType.APPLICATION_JSON_TYPE).post(ClientResponse.class);
         String result = response.getEntity(String.class);
         assertEquals(200, response.getStatus());
         assertEquals("[null,null]", result);
     }
-    
+
     @Test
     public void testQueryEndpointMultiAddSomeResults() throws Exception {
-        
+
         Node node=createNode("name","bar");
-        
+
         cypherRsPath.put(ClientResponse.class, UPDATE_QUERY);
         Map<String,Object> payload1 = map("id", node.getId());
         payload1.put("name", "Neo");
-        
+
         Map<String,Object> payload2 = map("id", -234);
         payload2.put("name", "Neo2");
-        
+
         List<Map<String,Object>> items = new ArrayList<>();
         items.add(payload1);
         items.add(payload2);
-        
+
         ClientResponse response =  cypherRsPath.entity(Utils.toJson(items), MediaType.APPLICATION_JSON_TYPE).post(ClientResponse.class);
         String result = response.getEntity(String.class);
         assertEquals(200, response.getStatus());
         assertEquals("[{\"name\":\"Neo\"},null]", result);
     }
-    
+
     @Test
     public void testQueryEndpointMultipleResults() throws Exception {
         Node andres=createNode("name","Andres");

--- a/src/test/java/org/neo4j/cypher_rs/LocalTestServer.java
+++ b/src/test/java/org/neo4j/cypher_rs/LocalTestServer.java
@@ -21,7 +21,6 @@ package org.neo4j.cypher_rs;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.helpers.collection.IteratorUtil;
 import org.neo4j.kernel.impl.core.GraphPropertiesImpl;
 import org.neo4j.kernel.impl.core.NodeManager;
 import org.neo4j.server.CommunityNeoServer;


### PR DESCRIPTION
- made separate commits since some versions are not binary compatible, so that maybe you can branch out of a given commit if needed.
- I'm not sure how you want to deal with `GraphDatabaseAPI` being deprecated for `GraphDatabaseService` since you rely on `DependencyResolver`. Is there a way to obtain the `NodeManager` or `GraphProperties` elsewhere?